### PR TITLE
New filter added to configure the API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /assets/*
 readme.txt
+.idea

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ extending the functionality of the built-in Google Map field with several handy 
 The plugin makes use of the Google Maps API version 3.<br>
 As the API key is now required, a new filter `acf/fields/google_map_extended/api` was configured to allow the user to add the key.
 
+Add this action in your **functions.php**:
+
+```
+add_action( 'acf/fields/google_map_extended/api', function( $key ) {
+	$key = 'YOUR_KEY';
+	return $key;
+} );
+```
+
 ## Usage
 
 Please see the [F.A.Q.](https://wordpress.org/plugins/advanced-custom-fields-google-map-extended/faq/) at WordPress.org

--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ extending the functionality of the built-in Google Map field with several handy 
 * Compatible with the ACF built-in Google Map field.
 * Saves all maps shown at a page in the global array. This is a bonus for programmers.
 
-The plugin makes use of the Google Maps API version 3.
-The plugin doesn't use an API key and is therefore operating under the [restrictions of the free Google Maps API](https://developers.google.com/maps/faq#usage_pricing),
-which should be more than enough for most websites.
+The plugin makes use of the Google Maps API version 3.<br>
+As the API key is now required, a new filter `acf/fields/google_map_extended/api` was configured to allow the user to add the key.
 
 ## Usage
 

--- a/acf-google-map-extended-base.php
+++ b/acf-google-map-extended-base.php
@@ -45,9 +45,12 @@ class acf_field_google_map_extended extends acf_field {
       'url' => plugins_url('',__FILE__),
       'version' => acf_field_google_map_extended_plugin::version,
       'script-handle' => 'acf-input-google-map-extended',
-      'acf-script-handle' => 'acf-input'
+      'acf-script-handle' => 'acf-input',
+      'key' => '',
     );
-    
+
+    // Applying the Google Maps key
+    $this->settings['key'] = apply_filters( 'acf/fields/google_map_extended/api', $this->settings['key'] );
   }
 }
 ?>

--- a/acf-google-map-extended-v4.php
+++ b/acf-google-map-extended-v4.php
@@ -25,7 +25,7 @@ class acf_field_google_map_extended_v4 extends acf_field_google_map_extended {
   * @return n/a
   */
   function input_admin_enqueue_scripts() {
-    wp_register_script("googlemaps-api", "//maps.googleapis.com/maps/api/js?v=3&sensor=false&libraries=places",array(),'3',false);
+    wp_register_script("googlemaps-api", "//maps.googleapis.com/maps/api/js?v=3&sensor=false&libraries=places&key=" . $this->settings['key'],array(),'3',false);
     //workaround script blocking ACF ver 4 from loading google maps twice
     wp_register_script('acf-input-google-load-workaround', $this->settings['url'] . '/js/acf4-fix.js', array('googlemaps-api'), $this->settings['version'],false);
     wp_register_script($this->settings['script-handle'], $this->settings['url'] . '/js/input.js', array('acf-input-google-load-workaround',$this->settings['acf-script-handle'],'jquery','googlemaps-api'), $this->settings['version'],false);

--- a/acf-google-map-extended-v4.php
+++ b/acf-google-map-extended-v4.php
@@ -25,7 +25,7 @@ class acf_field_google_map_extended_v4 extends acf_field_google_map_extended {
   * @return n/a
   */
   function input_admin_enqueue_scripts() {
-    wp_register_script("googlemaps-api", "//maps.googleapis.com/maps/api/js?v=3&sensor=false&libraries=places&key=" . $this->settings['key'],array(),'3',false);
+    wp_register_script("googlemaps-api", "//maps.googleapis.com/maps/api/js?v=3&libraries=places&key=" . $this->settings['key'],array(),'3',false);
     //workaround script blocking ACF ver 4 from loading google maps twice
     wp_register_script('acf-input-google-load-workaround', $this->settings['url'] . '/js/acf4-fix.js', array('googlemaps-api'), $this->settings['version'],false);
     wp_register_script($this->settings['script-handle'], $this->settings['url'] . '/js/input.js', array('acf-input-google-load-workaround',$this->settings['acf-script-handle'],'jquery','googlemaps-api'), $this->settings['version'],false);

--- a/acf-google-map-extended-v5.php
+++ b/acf-google-map-extended-v5.php
@@ -24,7 +24,7 @@ class acf_field_google_map_extended_v5 extends acf_field_google_map_extended {
   * @return n/a
   */
   function input_admin_enqueue_scripts() {
-    wp_register_script("googlemaps-api", "//maps.googleapis.com/maps/api/js?v=3&sensor=false&libraries=places",array(),'3',false);
+    wp_register_script("googlemaps-api", "//maps.googleapis.com/maps/api/js?v=3&sensor=false&libraries=places&key=" . $this->settings['key'],array(),'3',false);
     wp_register_script($this->settings['script-handle'], $this->settings['url'] . '/js/input.js', array($this->settings['acf-script-handle'],'jquery','googlemaps-api'), $this->settings['version'],false);
     wp_register_style($this->settings['script-handle'], $this->settings['url'] . '/css/input.css', array($this->settings['acf-script-handle']), $this->settings['version']); 
 

--- a/acf-google-map-extended-v5.php
+++ b/acf-google-map-extended-v5.php
@@ -24,7 +24,7 @@ class acf_field_google_map_extended_v5 extends acf_field_google_map_extended {
   * @return n/a
   */
   function input_admin_enqueue_scripts() {
-    wp_register_script("googlemaps-api", "//maps.googleapis.com/maps/api/js?v=3&sensor=false&libraries=places&key=" . $this->settings['key'],array(),'3',false);
+    wp_register_script("googlemaps-api", "//maps.googleapis.com/maps/api/js?v=3&libraries=places&key=" . $this->settings['key'],array(),'3',false);
     wp_register_script($this->settings['script-handle'], $this->settings['url'] . '/js/input.js', array($this->settings['acf-script-handle'],'jquery','googlemaps-api'), $this->settings['version'],false);
     wp_register_style($this->settings['script-handle'], $this->settings['url'] . '/css/input.css', array($this->settings['acf-script-handle']), $this->settings['version']); 
 

--- a/acf-google-map-extended.php
+++ b/acf-google-map-extended.php
@@ -14,7 +14,7 @@ Domain Path: /lang
 
 class acf_field_google_map_extended_plugin {
   
-  const version = '1.0.1';
+  const version = '1.0.2';
 
   function __construct() {
     add_action('plugins_loaded', array($this, 'plugins_loaded') );

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "juniorgarcia/acf-gme",
+  "type": "wordpress-plugin",
+  "description": "A extended version of ACF Google Maps plugin with some more functionality.",
+  "require": {
+    "composer/installers": "~1.0"
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -4,5 +4,8 @@
   "description": "A extended version of ACF Google Maps plugin with some more functionality.",
   "require": {
     "composer/installers": "~1.0"
+  },
+  "extra": {
+    "installer-name": "advanced-custom-fields-google-map-extended"
   }
 }


### PR DESCRIPTION
I have configured the filter `acf/fields/google_map_extended/api` as the API key is now required.